### PR TITLE
Update release.yml to use GPG_PRIVATE_KEY

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5.0.0
         with:
-          gpg_private_key: ${{ secrets.PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser


### PR DESCRIPTION
release.yml referred to the secret `PRIVATE_KEY` but it exists as `GPG_PRIVATE_KEY` only.